### PR TITLE
Return boolean in goBack function

### DIFF
--- a/lua/mkdnflow/files.lua
+++ b/lua/mkdnflow/files.lua
@@ -553,8 +553,10 @@ M.goBack = function()
         vim.api.nvim_command("buffer "..prev_buf)
         -- Pop the buffer we just navigated to off the top of the stack
         buffer_stack.pop('main')
+        return true
     else
         print([[Can't go back any further!]])
+        return false
     end
 end
 


### PR DESCRIPTION
Returns boolean flag in goBack function that is `true` if can go back and `false` if it can't.

## Reason
I'm using `<bs>` for my for a file browser (`dirvish`), but I also prefere to have it mapped to `goBack` when in markdawn files.
With this change I can set it up so I have my file browser opened when I cant go back. Works perfect for me and this change should not have any effect for existing users.

If you don't like this solution then maybe I can add public method  `canGoBack` and use that in my mapping?


My mapping for reference:
```
if not require('mkdnflow').files.goBack() then
  vim.cmd('Dirvish %:p')
end
```