### PR TITLE
Graceful fallback for nvim compiled without luajit

### DIFF
--- a/lua/mkdnflow/files.lua
+++ b/lua/mkdnflow/files.lua
@@ -18,7 +18,10 @@
 local M = {}
 
 -- Get OS for use in a couple of functions
-local this_os = jit.os
+local this_os = 'Unknown'
+if jit then
+    this_os = jit.os
+end
 -- Generic OS message
 local this_os_err = 'Function unavailable for '..this_os..'. Please file an issue.'
 -- Get config setting for whether to make missing directories or not


### PR DESCRIPTION
Lua proper does not provide the jit helper variable.

Nvim can be compiled with liblua5.1 in place of libluaji5.1. Luajit is
not available on all architectures.

This will make the Unix features unavailable even if the target platform
is Linux/MacOS when running under nvim compiled against liblua5.1, but
the plugin will not error out.