### PR TITLE
fix: crashes vim startup when no filename on the command-line

### DIFF
--- a/lua/mkdnflow/init.lua
+++ b/lua/mkdnflow/init.lua
@@ -37,8 +37,8 @@ init.loaded = nil
 
 -- Private function to detect the file's extension
 local getFileType = function()
-    local ext = string.lower(init.initial_buf:match("^.*%.(.+)$"))
-    return(ext)
+    local ext = init.initial_buf:match("^.*%.(.+)$")
+    return(ext ~= nil and string.lower(ext) or '')
 end
 
 init.setup = function(user_config)


### PR DESCRIPTION
When Vim is started without filename on the command-line, the plugin startup crashes:

![image](https://user-images.githubusercontent.com/8590051/152763646-2c61e12c-3895-48a1-b7d9-ee9d1c3db485.png)
