### PR TITLE
Custom link handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ I keep tabs on the project's [issues](https://github.com/jakewvincent/mkdnflow.n
 
 * Linux, macOS, or Windows
 * Neovim >= 0.5.0
+* (Optional: If you wish to use custom UTF-8 symbols as your to-do symbols, you'll need the luarocks module `luautf8`. Luarocks dependencies can be installed via [Packer](#initlua).)
 
 ### ➖ Differences from [Vimwiki](https://github.com/vimwiki/vimwiki)
 
@@ -120,6 +121,19 @@ require('mkdnflow').setup({
 
 ```lua
 use({'jakewvincent/mkdnflow.nvim',
+     config = function()
+        require('mkdnflow').setup({
+            -- Config goes here; leave blank for defaults
+        })
+     end
+})
+```
+
+#### If you wish to use custom UTF-8 to-do symbols, add the luautf8 luarock dependency
+
+```lua
+use({'jakewvincent/mkdnflow.nvim',
+     rocks = 'luautf8',
      config = function()
         require('mkdnflow').setup({
             -- Config goes here; leave blank for defaults

--- a/README.md
+++ b/README.md
@@ -238,7 +238,10 @@ require('mkdnflow').setup({
         MkdnToggleToDo = {'n', '<C-Space>'},
         MkdnNewListItem = false
     },
-    link_style = 'markdown',
+    links = {
+        style = 'markdown',
+        implicit_extension = nil
+    },
     to_do = {
         symbols = {' ', '-', 'X'},
         update_parents = true,
@@ -306,9 +309,12 @@ Note: See [default mappings](#-commands-and-default-mappings)
 
 Note: `<name of command>` should be the name of a commands defined in `mkdnflow.nvim/plugin/mkdnflow.lua` (see :h Mkdnflow-commands for a list).
 
-#### `link_style` (string)
-* `'markdown'`: Links will be expected in the standard markdown format: `[<title>](<source>)`
-* `'wiki'`: Links will be expected in the unofficial wiki-link style, specifically the [title-after-pipe format](https://github.com/jgm/pandoc/pull/7705): `[[<source>|<title>]]`. Following wiki-link conventions, `.md` sources within the notebook/wiki will not be expected to have the `.md` extension explicitly written in the link.
+#### `links` (dictionary table)
+* `links.style` (string)
+    * `'markdown'`: Links will be expected in the standard markdown format: `[<title>](<source>)`
+    * `'wiki'`: Links will be expected in the unofficial wiki-link style, specifically the [title-after-pipe format](https://github.com/jgm/pandoc/pull/7705): `[[<source>|<title>]]`.
+* `links.implicit_extension` (string)
+    * `<any extension>`: a string that instructs the plugin (a) how to _interpret_ links to files that do not have an extension, and (b) that new links should be created without an explicit extension
 
 #### `to_do` (dictionary table)
 * `to_do.symbols` (array table): A list of symbols (each no more than one character) that represent to-do list completion statuses. `MkdnToggleToDo` references these when toggling the status of a to-do item. Three are expected: one representing not-yet-started to-dos (default: `' '`), one representing in-progress to-dos (default: `-`), and one representing complete to-dos (default: `X`).

--- a/doc/mkdnflow.txt
+++ b/doc/mkdnflow.txt
@@ -301,6 +301,14 @@ A sample config showing the defaults:~
             evaluate = true,
             string = [[os.date('%Y-%m-%d_')]]
         },
+        links = {
+            style = 'markdown', -- 'markdown' | 'wiki'
+            implicit_extension = nil,
+            transform = false -- false |
+                              -- a lua function to transform the link content
+                              -- in the latter case links are created and followed
+                              -- after applying the function but written without the transformation
+        },
         wrap = false,
         default_bib_path = '',
         use_mappings_table = true,

--- a/lua/mkdnflow/compat.lua
+++ b/lua/mkdnflow/compat.lua
@@ -83,8 +83,10 @@ M.userConfigCheck = function(user_config)
         user_config.links.style = user_config.link_style
     end
     -- Look for implicit extension and remove periods
-    if user_config.links.implicit_extension then
-        user_config.links.implicit_extension = string.gsub(user_config.links.implicit_extension, '%.', '')
+    if user_config.links then
+        if user_config.links.implicit_extension then
+            user_config.links.implicit_extension = string.gsub(user_config.links.implicit_extension, '%.', '')
+        end
     end
     -- Look for old prefix settings
     if user_config.evaluate_prefix or user_config.new_file_prefix then

--- a/lua/mkdnflow/compat.lua
+++ b/lua/mkdnflow/compat.lua
@@ -78,6 +78,14 @@ M.userConfigCheck = function(user_config)
             end
         end
     end
+    -- Look for link style
+    if user_config.link_style then
+        user_config.links.style = user_config.link_style
+    end
+    -- Look for implicit extension and remove periods
+    if user_config.links.implicit_extension then
+        user_config.links.implicit_extension = string.gsub(user_config.links.implicit_extension, '%.', '')
+    end
     -- Look for old prefix settings
     if user_config.evaluate_prefix or user_config.new_file_prefix then
         user_config.prefix = {

--- a/lua/mkdnflow/cursor.lua
+++ b/lua/mkdnflow/cursor.lua
@@ -18,7 +18,7 @@
 local links = require('mkdnflow.links')
 local wrap = require('mkdnflow').config.wrap
 local silent = require('mkdnflow').config.silent
-local link_style = require('mkdnflow').config.link_style
+local link_style = require('mkdnflow').config.links.style
 
 --[[
 rev_get_line() retrieves line text and reverses it

--- a/lua/mkdnflow/init.lua
+++ b/lua/mkdnflow/init.lua
@@ -228,6 +228,7 @@ init.setup = function(user_config)
             end
         end
         -- Load functions
+        init.utils = require('mkdnflow.utils')
         init.cursor = require('mkdnflow.cursor')
         if init.this_os == 'Windows_NT' then
             init.paths = require('mkdnflow.paths_windows')

--- a/lua/mkdnflow/init.lua
+++ b/lua/mkdnflow/init.lua
@@ -37,7 +37,8 @@ local default_config = {
     --link_style = 'markdown',
     links = {
         style = 'markdown',
-        implicit_extension = nil
+        implicit_extension = nil,
+        transform = false
     },
     to_do = {
         symbols = {' ', '-', 'X'},

--- a/lua/mkdnflow/init.lua
+++ b/lua/mkdnflow/init.lua
@@ -34,7 +34,11 @@ local default_config = {
     wrap = false,
     default_bib_path = '',
     silent = false,
-    link_style = 'markdown',
+    --link_style = 'markdown',
+    links = {
+        style = 'markdown',
+        implicit_extension = nil
+    },
     to_do = {
         symbols = {' ', '-', 'X'},
         update_parents = true,

--- a/lua/mkdnflow/init.lua
+++ b/lua/mkdnflow/init.lua
@@ -187,7 +187,9 @@ init.setup = function(user_config)
     -- Before fully loading config see if the plugin should be started
     local load_on_ft = default_config.filetypes
     if next(user_config) then
-        load_on_ft = MergeConfigs(load_on_ft, user_config.filetypes)
+        if user_config.filetypes then
+            load_on_ft = MergeConfigs(load_on_ft, user_config.filetypes)
+        end
         init.user_config = user_config
     end
     -- Load extension if the filetype has a match in config.filetypes

--- a/lua/mkdnflow/init.lua
+++ b/lua/mkdnflow/init.lua
@@ -163,6 +163,8 @@ end
 
 -- Initialize "init" table
 local init = {}
+-- Table to store user config
+init.user_config = {}
 -- Table to store merged configs
 init.config = {}
 -- Initialize a variable for load status
@@ -186,6 +188,7 @@ init.setup = function(user_config)
     local load_on_ft = default_config.filetypes
     if next(user_config) then
         load_on_ft = MergeConfigs(load_on_ft, user_config.filetypes)
+        init.user_config = user_config
     end
     -- Load extension if the filetype has a match in config.filetypes
     if load_on_ft[ft] then
@@ -265,8 +268,8 @@ init.forceStart = function()
     if init.loaded == true then
         vim.api.nvim_echo({{"⬇️  Mkdnflow is already running!", 'ErrorMsg'}}, true, {})
     else
-        vim.api.nvim_echo({{"⬇️  Starting Mkdnflow with defaults. Please call the setup function in your config or modify the 'filetypes' key in the setup table for this filetype.", 'WarningMsg'}}, true, {})
-        init.setup({})
+        vim.api.nvim_echo({{"⬇️  Starting Mkdnflow.", 'WarningMsg'}}, true, {})
+        init.setup(init.user_config)
     end
 end
 

--- a/lua/mkdnflow/links.lua
+++ b/lua/mkdnflow/links.lua
@@ -20,7 +20,8 @@ local new_file_prefix = require('mkdnflow').config.prefix.string
 -- Get the user's prefix evaluation preference
 local evaluate_prefix = require('mkdnflow').config.prefix.evaluate
 local this_os = require('mkdnflow').this_os
-local link_style = require('mkdnflow').config.link_style
+local link_style = require('mkdnflow').config.links.style
+local implicit_extension = require('mkdnflow').config.links.implicit_extension
 
 -- Table for global functions
 local M = {}
@@ -326,9 +327,17 @@ M.formatLink = function(text, part)
         local path_text = string.gsub(text, " ", "-")
         local replacement
         if link_style == 'wiki' then
-            replacement = {'[['..prefix..string.lower(path_text)..'|'..text..']]'}
+            if implicit_extension then
+                replacement = {'[['..prefix..string.lower(path_text)..'|'..text..']]'}
+            else
+                replacement = {'[['..prefix..string.lower(path_text)..'.md|'..text..']]'}
+            end
         else
-            replacement = {'['..text..']'..'('..prefix..string.lower(path_text)..'.md)'}
+            if implicit_extension then
+                replacement = {'['..text..']'..'('..prefix..string.lower(path_text)..')'}
+            else
+                replacement = {'['..text..']'..'('..prefix..string.lower(path_text)..'.md)'}
+            end
         end
         if part == nil then
             return(replacement)
@@ -388,16 +397,7 @@ M.createLink = function()
             -- Get the word under the cursor
             local cursor_word = vim.fn.expand('<cword>')
             -- Make a markdown link out of the date and cursor
-            local replacement
-            if link_style == 'wiki' then
-                replacement = {
-                    '[['..prefix..string.lower(cursor_word)..'|'..cursor_word..']]'
-                }
-            else
-                replacement = {
-                    '['..cursor_word..']'..'('..prefix..string.lower(cursor_word)..'.md)'
-                }
-            end
+            local replacement = M.formatLink(cursor_word)
             -- Find the (first) position of the matched word in the line
             local left, right = string.find(line, cursor_word, nil, true)
             -- Make sure it's not a duplicate of the word under the cursor, and if it

--- a/lua/mkdnflow/links.lua
+++ b/lua/mkdnflow/links.lua
@@ -83,17 +83,17 @@ M.getLinkPart = function(part)
         if part == 'name' then
             if link_type == 'address' then
                 local name_pattern
+                local link = string.sub(line[1], indices['com'], indices['fin'])
                 if link_style == 'wiki' then
-                    name_pattern = '%[%[(|.*%])%]'
+                    if link:match('|') then
+                        name_pattern = '%[%[.*(|.*%])%]'
+                    else
+                        name_pattern = '%[(.*)%]'
+                    end
                 else
                     name_pattern = '(%b[])%b()'
                 end
-                local name = string.sub(
-                    string.match(
-                        string.sub(line[1], indices['com'], indices['fin']),
-                        name_pattern
-                    ), 2, -2
-                )
+                local name = string.sub(string.match(link, name_pattern), 2, -2)
                 -- Return the name and the indices of the link
                 return name, indices['com'], indices['fin'], row
             end

--- a/lua/mkdnflow/links.lua
+++ b/lua/mkdnflow/links.lua
@@ -293,7 +293,7 @@ M.formatLink = function(text, part)
     -- If the text starts with a hash, format the link as an anchor link
     if string.sub(text, 0, 1) == '#' then
         local name = string.gsub(text, '^#* *', '')
-        local path_text = string.gsub(text, '[^%a%s%d%-]', '')
+        local path_text = string.gsub(text, '[^%a%s%d%-_]', '')
         path_text = string.gsub(path_text, '^ ', '')
         path_text = string.gsub(path_text, ' ', '-')
         path_text = string.gsub(path_text, '%-%-', '-')

--- a/lua/mkdnflow/lists.lua
+++ b/lua/mkdnflow/lists.lua
@@ -31,7 +31,10 @@ end
 
 local update_numbering = function(row, starting_number)
     local next_line = vim.api.nvim_buf_get_lines(0, row + 1, row + 2, false)
-    local is_numbered = next_line[1]:match('^(%s*%d+%.%s*).-')
+    local is_numbered
+    if next_line[1] then
+        is_numbered = next_line[1]:match('^(%s*%d+%.%s*).-')
+    end
     while is_numbered do
         -- Replace the number on whichever line
         --local item_number = is_numbered:match('^%s*(%d*)%.')

--- a/lua/mkdnflow/lists.lua
+++ b/lua/mkdnflow/lists.lua
@@ -292,7 +292,6 @@ M.newListItem = function()
     else
         -- Then look for a to-do item
         match = line:match('^%s*[*-]%s+%[.%]%s+[^%s]+')
-        print(match)
         partial_match = line:match('^(%s*[-*]%s+%[.%]%s).-')
         if partial_match and not match then
             local row = vim.api.nvim_win_get_cursor(0)[1]

--- a/lua/mkdnflow/paths.lua
+++ b/lua/mkdnflow/paths.lua
@@ -30,6 +30,7 @@ local initial_dir = require('mkdnflow').initial_dir
 local root_dir = require('mkdnflow').root_dir
 local silent = require('mkdnflow')
 local implicit_extension = require('mkdnflow').config.links.implicit_extension
+local link_transform = require('mkdnflow').config.links.transform
 
 -- Load modules
 local buffers = require('mkdnflow.buffers')

--- a/lua/mkdnflow/paths.lua
+++ b/lua/mkdnflow/paths.lua
@@ -29,7 +29,8 @@ local initial_dir = require('mkdnflow').initial_dir
 -- Get root_dir for notebook/wiki
 local root_dir = require('mkdnflow').root_dir
 local silent = require('mkdnflow')
-local link_style = require('mkdnflow').config.link_style
+local link_style = require('mkdnflow').config.links.style
+local implicit_extension = require('mkdnflow').config.links.implicit_extension
 
 -- Load modules
 local buffers = require('mkdnflow.buffers')
@@ -269,8 +270,10 @@ Returns nothing
 M.handlePath = function(path, anchor)
     anchor = anchor or false
     if path_type(path) == 'filename' then
-        if link_style == 'wiki' then
-            if not path:match('%.md$') then
+        if not path:match('%.md$') then
+            if implicit_extension then
+                path = path..'.'..implicit_extension
+            else
                 path = path..'.md'
             end
         end

--- a/lua/mkdnflow/paths.lua
+++ b/lua/mkdnflow/paths.lua
@@ -29,7 +29,6 @@ local initial_dir = require('mkdnflow').initial_dir
 -- Get root_dir for notebook/wiki
 local root_dir = require('mkdnflow').root_dir
 local silent = require('mkdnflow')
-local link_style = require('mkdnflow').config.links.style
 local implicit_extension = require('mkdnflow').config.links.implicit_extension
 
 -- Load modules
@@ -256,6 +255,19 @@ end
 
 local M = {}
 
+
+--[[
+transformPath() takes a string and transforms it with a user-defined function if
+it was set. Otherwise returns the string / path unchanged.
+--]]
+M.transformPath = function (path)
+  if not link_transform then
+    return path
+  else
+    return link_transform(path)
+  end
+end
+
 --[[
 handlePath() does something with the path in the link under the cursor:
      1. Creates the file specified in the path, if the path is determined to
@@ -269,6 +281,7 @@ Returns nothing
 --]]
 M.handlePath = function(path, anchor)
     anchor = anchor or false
+    path = M.transformPath(path)
     if path_type(path) == 'filename' then
         if not path:match('%.md$') then
             if implicit_extension then

--- a/lua/mkdnflow/paths_windows.lua
+++ b/lua/mkdnflow/paths_windows.lua
@@ -29,7 +29,6 @@ local initial_dir = require('mkdnflow').initial_dir
 -- Get root_dir for notebook/wiki
 local root_dir = require('mkdnflow').root_dir
 local silent = require('mkdnflow').config.silent
-local link_style = require('mkdnflow').config.links.style
 local implicit_extension = require('mkdnflow').config.links.implicit_extension
 
 -- Load modules
@@ -37,6 +36,7 @@ local buffers = require('mkdnflow.buffers')
 local bib = require('mkdnflow.bib')
 local cursor = require('mkdnflow.cursor')
 local links = require('mkdnflow.links')
+local paths = require('mkdnflow.paths')
 
 --[[
 path_type() determines what kind of path is in a url
@@ -238,6 +238,7 @@ handlePath() does something with the path in the link under the cursor:
 Returns nothing
 --]]
 M.handlePath = function(path, anchor)
+    path = paths.transformPath(path)
     if path_type(path) == 'filename' then
         if not path:match('%.md$') then
             if implicit_extension then

--- a/lua/mkdnflow/paths_windows.lua
+++ b/lua/mkdnflow/paths_windows.lua
@@ -29,7 +29,8 @@ local initial_dir = require('mkdnflow').initial_dir
 -- Get root_dir for notebook/wiki
 local root_dir = require('mkdnflow').root_dir
 local silent = require('mkdnflow').config.silent
-local link_style = require('mkdnflow').config.link_style
+local link_style = require('mkdnflow').config.links.style
+local implicit_extension = require('mkdnflow').config.links.implicit_extension
 
 -- Load modules
 local buffers = require('mkdnflow.buffers')
@@ -238,8 +239,10 @@ Returns nothing
 --]]
 M.handlePath = function(path, anchor)
     if path_type(path) == 'filename' then
-        if link_style == 'wiki' then
-            if not path:match('%.md$') then
+        if not path:match('%.md$') then
+            if implicit_extension then
+                path = path..'.'..implicit_extension
+            else
                 path = path..'.md'
             end
         end

--- a/lua/mkdnflow/utils.lua
+++ b/lua/mkdnflow/utils.lua
@@ -1,0 +1,35 @@
+-- mkdnflow.nvim (Tools for personal markdown notebook navigation and management)
+-- Copyright (C) 2022 Jake W. Vincent <https://github.com/jakewvincent>
+--
+-- This program is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+local M = {}
+
+M.moduleAvailable = function(name)
+  if package.loaded[name] then
+    return true
+  else
+    for _, searcher in ipairs(package.searchers or package.loaders) do
+      local loader = searcher(name)
+      if type(loader) == 'function' then
+        package.preload[name] = loader
+        return true
+      end
+    end
+    return false
+  end
+end
+
+
+return M


### PR DESCRIPTION
Based on the discussion in https://github.com/jakewvincent/mkdnflow.nvim/issues/10

This adds the ability to pass a user-defined lua function to internally transform the path of a link.
Where internally means that the link will be displayed and written in the document un-transformed but it's transformed version will be used for file-creation and navigation.

This is helpful for navigating e.g. a folder of files created by https://logseq.com/

Note: In logseq one can choose the way dates for journal entries are displayed. For example, if the option YYYY-MM-DD is choosed this config works:

```
    perspective = {
        priority = 'root',
        fallback = 'current',
        root_tell = ".git"
    },
    prefix = {
        evaluate = false,
        string = "./"
    },
    links = {
        style = 'wiki',
        implicit_extension = nil,
        transform = function(input)
            if input:match('%d%d%d%d%-%d%d%-%d%d') then
                return('journals/'..input:gsub("%-","_"))
            else
                return('pages/'..input)
            end
        end
    },
```

It can now succesfullly open pages in `pages`, even those created by logseq for zotero entries, which logseq puts as `pages/@...`, as well as journal pages in `journal`.

