### PR TITLE
Support forward slash in windows paths

### DIFF
--- a/lua/mkdnflow/paths_windows.lua
+++ b/lua/mkdnflow/paths_windows.lua
@@ -79,6 +79,7 @@ local handle_internal_file = function(path, anchor)
             cursor.toHeading(anchor_)
         end
     end
+    path = path:gsub('/', '\\')
     -- Decide what to pass to above local function
     if path:match('^%u:\\') then
         internal_open(path, anchor)


### PR DESCRIPTION
Windows supports both forward slashes and back slashes in pathing. Those slashes will usually get fixed up to the Windows default of back slash after the fact. However, this isn't true in nvim... this creates issues when using local pathing.

Assumes you start in ~\A\file.md and file.md has a link to B/ref.md.  B/ref.md will open with no issues.  However when grabbing the local path via vim.api.nvim_buf_get_name(0) it will return: ~\A/B/ref.md.  This ends up breaking the local pathing logic in paths_windows as it assumes all elements of the path are using back slash (via this logic: string.match(cur_file, '(.*)\\.-$')).  This PR fixes up the local pathing logic to update the path before applying any logic to it to ensure consistent slashing.

Note: I only applied this to internal files as external files are a one way trip so I'd rather leave them alone instead of having to sort out making sure URLs etc. aren't mangled.

Testing: Using my Windows machine to test the new jumping logic and confirm the local pathing logic now follows the current directory even if the link that brought you there contained '/'.