### PR TITLE
Fix opening urls with hashes `#`

### DIFF
--- a/lua/mkdnflow/paths.lua
+++ b/lua/mkdnflow/paths.lua
@@ -171,6 +171,8 @@ Returns nothing
 --]]
 local open = function(path, type)
     local shell_open = function(path_)
+        path_ = "'"..path_:gsub('#', '\\#').."'"
+        
         if this_os == "Linux" then
             vim.api.nvim_command('silent !xdg-open '..path_)
         elseif this_os == "Darwin" then


### PR DESCRIPTION
`vim.api.nvim_command` fails when the hash sign (#) is not escaped, also added single quotes around the path for a bit more sane execution. 

Only tested on Linux, however I think 😇  it should also work for OSX and Windows.