### PR TITLE
make anchor link jump support jumplist

### DIFF
--- a/lua/mkdnflow/cursor.lua
+++ b/lua/mkdnflow/cursor.lua
@@ -169,6 +169,8 @@ go_to_heading() finds a heading for the text passed in from an anchor link. If
 no argument is provided, it goes to the next heading it can find, if possible.
 --]]
 local go_to_heading = function(anchor_text, reverse)
+    -- add cursor position to jumplist
+	vim.cmd([[ normal! m' ]])
     -- Record which line we're on; chances are the link goes to something later,
     -- so we'll start looking from here onwards and then circle back to the beginning
     local position = vim.api.nvim_win_get_cursor(0)


### PR DESCRIPTION
 Set a mark before the anchor links jump doesn't seem to support jumplist eg: `<ctrl-i>` and `<ctrl-o>`


https://user-images.githubusercontent.com/43649186/212915179-7625754f-2792-4044-9ae0-67a2b10abf6e.mp4

so i add `vim.cmd [[ normal! m' ]]`  <https://neovim.discourse.group/t/how-to-add-the-current-cursor-position-to-the-jump-list/1585>


https://user-images.githubusercontent.com/43649186/212915739-efbc9f28-fd85-487c-aeee-a9de10895e88.mp4

