### PR TITLE
Insert a new to-do item on to-do toggle in case it's not found

### DIFF
--- a/lua/mkdnflow/lists.lua
+++ b/lua/mkdnflow/lists.lua
@@ -394,8 +394,8 @@ M.toggleToDo = function(row, status, meta)
                 end
             end
         else
-            local message = '⬇️  Not a to-do list item!'
-            if not silent then vim.api.nvim_echo({{message, 'WarningMsg'}}, true, {}) end
+            -- No to-do found, insert one.
+            vim.api.nvim_buf_set_text(0, row - 1, 0, row - 1, 0, { '- [' .. to_do_not_started .. '] ' })
         end
     end
 end


### PR DESCRIPTION
Hi @jakewvincent! Thank you for this beautiful plugin, `mkdnflow` was a missing piece in my dream setup of an Obsidian-compatible, full-blown `nvim`-based markdown KMS with [`zk`](https://github.com/mickael-menu/zk-nvim) ❤️ 

In my workflow, I heavily rely on to-do lists, and the functionality provided by `mkdnflow` is just superb! However, I have one (perhaps controversial) improvement to suggest: **insert a todo-list item in case it's not found on toggle**. 

It's tedious to constantly have to write a `- [ ] `. This PR allows to just navigate to a future to-do list item, and toggle it into existence (and transition it into a desired state) with one command, here's a little demo:

https://user-images.githubusercontent.com/4748206/229793220-70771cc0-9277-4eab-9156-29ea1d566626.mov