### PR TITLE
tables: fix the cell length calculation

### DIFF
--- a/lua/mkdnflow/tables.lua
+++ b/lua/mkdnflow/tables.lua
@@ -29,7 +29,7 @@ local width = function(string)
     if utf8_available then
         return require('lua-utf8').width(string)
     else
-        return #string
+        return vim.api.nvim_strwidth(string)
     end
 end
 


### PR DESCRIPTION
Fixes the formatting of tables containing Cyrillic, Kanu, etc.

before:
```
| немного кириллиц | 仮名 |
| ------------------------------- | ------ |
|                                 |        |
```

after:
```
| немного кириллиц | 仮名 |
| ---------------- | ---- |
|                  |      |
```