### PR TITLE
Bugfix: Formatting is broken when Japanese/emoji is entered in the ta…

### DIFF
--- a/lua/mkdnflow/tables.lua
+++ b/lua/mkdnflow/tables.lua
@@ -26,11 +26,7 @@ end
 local M = {}
 
 local width = function(string)
-    if utf8_available then
-        return require('lua-utf8').width(string)
-    else
-        return #string
-    end
+		return vim.fn.strdisplaywidth(string)
 end
 
 local extract_cell_data = function(text)


### PR DESCRIPTION
…ble.#160

Fixed by counting the number of characters in the cell with `vim.fn.strdisplaywidth(content)`.

https://github.com/jakewvincent/mkdnflow.nvim/assets/55862484/2149b0f9-0941-46ce-b096-2f31f539da3e

