### PR TITLE
nvim-cmp autocompletion for .md files and citation keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,7 +366,8 @@ require('mkdnflow').setup({
         maps = true,
         paths = true,
         tables = true,
-        yaml = false
+        yaml = false,
+        cmp = true
     },
     filetypes = {md = true, rmd = true, markdown = true},
     create_dirs = true,             
@@ -795,3 +796,39 @@ end
 * [wiki.vim](https://github.com/lervag/wiki.vim/) (A lighter-weight alternative to Vimwiki, written in Vimscript)
 * [Neorg](https://github.com/nvim-neorg/neorg) (A revised [Org-mode](https://en.wikipedia.org/wiki/Org-mode) for Neovim, written in Lua)
 * [follow-md-links.nvim](https://github.com/jghauser/follow-md-links.nvim) (A simpler plugin for following markdown links, written in Lua)
+=======
+
+# nvim-cmp autocompletion
+
+
+* Autocompletion in insert mode when the word you are typing matches any of the *.md* files in the notebook.
+* Autocompletion for bibliography key from entries in *.bib* files.
+* Documentation options to check the contents before selecting the completion.
+* A module for completion that can be disabled in configuration. Use the *cmp* key.
+
+
+Add this sources into the list of sources in your *init.lua* file.
+```lua
+cmp.setup({
+	sources = cmp.config.sources({
+		----- Rest of the sources
+
+		{ name = 'mkdnflow' },  -- new source
+	}),
+})
+```
+
+Also, don't forget to edit your `formatting` options in `cmp.setup`.
+
+
+#### possible completion issues with links.transform functions
+
+If you have some *transform_explicit* option for *links* to organizing in folders then the folder name will be inserted accordingly. **All transforms may not work**
+For example you have an implicit transform that will make the link as `[auther_year] (author_year.md)` and save the file as `ref_author_year.md`. The condition can be if the link name ends with *_yyyy*.
+Now cmp will complete it as `[ref_author_year] (ref_author_year.md)`.
+Now when you enter the link completed by cmp, you will go to a new file that is saved as `ref_ref_author_year.md`
+
+So have sensible transform functions, preferably organizing in folders. The other solution is to do a full text search in all the files for links, which is .. too much for me.
+
+
+I should credit the following developer of [cmp-pandoc-references](https://github.com/jc-doyle/cmp-pandoc-references) whose code i copied. And other nvim-cmp plugins i referred to for syntax etc.

--- a/README.md
+++ b/README.md
@@ -828,7 +828,7 @@ For example you have an implicit transform that will make the link as `[auther_y
 Now cmp will complete it as `[ref_author_year] (ref_author_year.md)`.
 Now when you enter the link completed by cmp, you will go to a new file that is saved as `ref_ref_author_year.md`
 
-So have sensible transform functions, preferably organizing in folders. The other solution is to do a full text search in all the files for links, which is .. too much for me.
+So have sensible transform functions, preferably organizing in folders. The other solution is to do a full text search in all the files for links.
 
 
 I should credit the following developer of [cmp-pandoc-references](https://github.com/jc-doyle/cmp-pandoc-references) whose code i copied. And other nvim-cmp plugins i referred to for syntax etc.

--- a/lua/mkdnflow.lua
+++ b/lua/mkdnflow.lua
@@ -30,7 +30,8 @@ local default_config = {
         maps = true,
         paths = true,
         tables = true,
-        yaml = false
+        yaml = false,
+        cmp = true,
     },
     perspective = {
         priority = 'first',
@@ -261,6 +262,7 @@ init.setup = function(user_config)
         init.paths = init.config.modules.paths and require('mkdnflow.paths')
         init.tables = init.config.modules.tables and require('mkdnflow.tables')
         init.yaml = init.config.modules.yaml and require('mkdnflow.yaml')
+        init.cmp = init.config.modules.cmp and require('mkdnflow.cmp')
         -- Record load status (i.e. loaded)
         init.loaded = true
     else

--- a/lua/mkdnflow/cmp.lua
+++ b/lua/mkdnflow/cmp.lua
@@ -124,6 +124,12 @@ function source:complete(params, callback)
 			table.insert(items, item)
 		end
 	end
+	for _, v in pairs(bib_paths.yaml) do
+		local bib_items_yaml = parse_bib(v)
+		for _, item in ipairs(bib_items_yaml) do
+			table.insert(items, item)
+		end
+	end
 	callback(items)
 end
 

--- a/lua/mkdnflow/cmp.lua
+++ b/lua/mkdnflow/cmp.lua
@@ -1,0 +1,133 @@
+
+local mkdnflow_root_dir = require('mkdnflow').root_dir  -- String
+local bib_paths = require('mkdnflow').bib.bib_paths
+-- local mkdnflow_root_dir = '../..'
+-- local mkdnflow_root_dir = 'asdfasdfasdfsadfasdf'
+local plenary_scandir = require('plenary').scandir.scan_dir  -- Function
+local cmp = require('cmp')
+-- local plenary_path = require('plenary').path
+local extension = '.md'  -- keep the .
+
+local transform_explicit_function_in_config = require('mkdnflow').config.links.transform_explicit
+
+
+local function transform_explicit(text)
+	if transform_explicit_function_in_config then  -- condition will be false if it doesn't exist
+		return transform_explicit_function_in_config(text)
+	else
+		return text
+	end
+end
+
+
+local function get_files_items()
+	local filepaths_in_root = plenary_scandir(mkdnflow_root_dir)
+	local items = {}
+	for _, path in ipairs(filepaths_in_root) do
+		if vim.endswith(path, extension) then
+			local item = {}
+			item.path = path  -- absolute path of the file
+			-- anything except / and \ (\\) followed by extension so that folders will be excluded
+			item.label = path:match('([^/^\\]+)'..extension..'$')
+			local explicit_link = transform_explicit(item.label) .. extension
+			-- text should be inserted in fmarkdown format
+			item.insertText = '['..item.label..']('..explicit_link..')'
+			-- for butification
+			item.kind = cmp.lsp.CompletionItemKind.File
+
+			local filepath = item.path
+			local binary = assert(io.open(filepath, 'rb'))
+			local first_kb = binary:read(1024)
+
+			local contents = {}
+			if first_kb then  -- if its not empty file
+				for content in first_kb:gmatch("[^\r\n]+") do
+					table.insert(contents, content)
+				end
+			end
+
+			item.documentation = { kind = cmp.lsp.MarkupKind.Markdown, value = first_kb }
+
+			table.insert(items, item)
+		end
+	end
+	return items
+end
+
+
+-- Remove newline & excessive whitespace. Will be used in parse_bib function
+local function clean(text)
+  if text then
+    text = text:gsub('\n', ' ')
+    return text:gsub('%s%s+', ' ')
+  else
+    return text
+  end
+end
+
+
+-- Parses the .bib file, formatting the completion item
+-- Adapted from http://rgieseke.github.io/ta-bibtex/
+local function parse_bib(filename)
+	local items = {}
+	local file = io.open(filename, 'rb')
+	local bibentries = file:read('*all')
+	file:close()
+	-- if not file then  -- check if you are able to open the file
+	-- 	bibentries = file:read('*all')
+	-- 	file:close()
+	-- end
+	-- print('bibentries are ' .. bibentries)
+	for bibentry in bibentries:gmatch('@.-\n}\n') do
+		local item = {}
+
+		local title = clean(bibentry:match('title%s*=%s*["{]*(.-)["}],?')) or ''
+		local author = clean(bibentry:match('author%s*=%s*["{]*(.-)["}],?')) or ''
+		local year = bibentry:match('year%s*=%s*["{]?(%d+)["}]?,?') or ''
+
+		local doc = {'**' .. title .. '**', '', '*' .. author .. '*', year}
+
+		item.documentation = {
+			kind = cmp.lsp.MarkupKind.Markdown,
+			value = table.concat(doc, '\n')
+		}
+		item.label = '@' .. bibentry:match('@%w+{(.-),')
+		item.kind = cmp.lsp.CompletionItemKind.Reference
+		item.insertText = item.label
+
+		table.insert(items, item)
+	end
+	return items
+end
+
+-------------------------------------------------------------- cmp source
+
+local source = {}
+
+source.new = function()
+	return setmetatable({}, { __index = source })
+end
+
+
+function source:complete(params, callback)
+	local items = get_files_items()
+	-- for bib files there are three lists (tables) that may store the bib file paths
+	for _, v in pairs(bib_paths.default) do
+		local bib_items_default = parse_bib(v)
+		for _, item in ipairs(bib_items_default) do
+			table.insert(items, item)
+		end
+	end
+	for _, v in pairs(bib_paths.root) do
+		local bib_items_root = parse_bib(v)
+		for _, item in ipairs(bib_items_root) do
+			table.insert(items, item)
+		end
+	end
+	callback(items)
+end
+
+
+-- return source  -- done in usual cmp method where the next line is present in after/plugin/file.lua or plugin/file.lua
+
+require('cmp').register_source('mkdnflow', source.new())


### PR DESCRIPTION
Added a new module called *cmp* which can be disabled in config.

This pull request gives autocompletion support when typing in insert mode. 
Here are some imaegs
![Screenshot from 2023-07-01 06-14-25](https://github.com/jakewvincent/mkdnflow.nvim/assets/32128870/4ecc00d1-09cf-4741-90a6-773e950b0d7d)
![Screenshot from 2023-07-01 06-15-33](https://github.com/jakewvincent/mkdnflow.nvim/assets/32128870/01259434-8154-413e-bc8a-8a266aa34986)
![Screenshot from 2023-07-01 06-14-04](https://github.com/jakewvincent/mkdnflow.nvim/assets/32128870/f5434c62-cc36-4e6b-8d2d-a6ca5afeea5f)
![Screenshot from 2023-07-01 06-13-55](https://github.com/jakewvincent/mkdnflow.nvim/assets/32128870/0e2877d9-4329-4e67-8d38-d6d45a4f9fcf)



One has to add the new source called 'mkdnflow' in their nvim-cmp config. This cmp source will work only inside a working zencaster notebook where a root directory is identified.

All the *.md* files in the notebook are displayed in the completion menu, without any foldername or extension. A valid link is inserted after selection.

Bibliography file parsing is taken from [cmp-pandoc-references](https://github.com/jc-doyle/cmp-pandoc-references)