### PR TITLE
fix: events no longer can be comma separated

### DIFF
--- a/lua/mkdnflow/maps.lua
+++ b/lua/mkdnflow/maps.lua
@@ -26,7 +26,7 @@ end
 -- Enable mappings in buffers in which Mkdnflow activates
 if nvim_version >= 7 then
     vim.api.nvim_create_augroup('MkdnflowMappings', { clear = true })
-    vim.api.nvim_create_autocmd({ 'BufEnter, BufWinEnter' }, {
+    vim.api.nvim_create_autocmd({ 'BufEnter', 'BufWinEnter' }, {
         pattern = extension_patterns,
         callback = function()
             for command, mapping in pairs(config.mappings) do


### PR DESCRIPTION
After https://github.com/neovim/neovim/pull/25523 the comma separated events are not valid any more and will throw error

<details>

```sh
Failed to run `config` for mkdnflow.nvim                                                                                                                                                        
                                                                                                                                                                                                
...ocal/share/nvim/lazy/mkdnflow.nvim/lua/mkdnflow/maps.lua:29: Invalid 'event': 'BufEnter, BufWinEnter'                                                                                        
                                                                                                                                                                                                
# stacktrace:                                                                                                                                                                                   
  - /mkdnflow.nvim/lua/mkdnflow/maps.lua:29                                                                                                                                                     
  - /mkdnflow.nvim/lua/mkdnflow.lua:303 _in_ **setup**                                                                                                                                          
  - ~/.config/nvim/lua/_lazy.lua:19                                                                                                                                                             
  - lua:1                                                                                                                                                                                       
```

</details>