### PR TITLE
fix: events no longer can be comma separated

### DIFF
--- a/lua/mkdnflow/maps.lua
+++ b/lua/mkdnflow/maps.lua
@@ -26,7 +26,7 @@ end
 -- Enable mappings in buffers in which Mkdnflow activates
 if nvim_version >= 7 then
     vim.api.nvim_create_augroup('MkdnflowMappings', { clear = true })
-    vim.api.nvim_create_autocmd({ 'BufEnter, BufWinEnter' }, {
+    vim.api.nvim_create_autocmd({ 'BufEnter', 'BufWinEnter' }, {
         pattern = extension_patterns,
         callback = function()
             for command, mapping in pairs(config.mappings) do


### PR DESCRIPTION
After neovim/neovim#25523 the comma separated events are not valid any
more and will throw error

credit @deathmaz

fixes #174 

Note: In case #173 can't be merged due to being unsigned
