### PR TITLE
add edit_dirs option

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,6 +400,7 @@ require('mkdnflow').setup({
     },
     filetypes = {md = true, rmd = true, markdown = true},
     create_dirs = true,             
+    edit_dirs = false,
     perspective = {
         priority = 'first',
         fallback = 'current',
@@ -514,6 +515,11 @@ require('mkdnflow').setup({
 #### `create_dirs` (boolean)
 * `true` (default): Directories referenced in a link will be (recursively) created if they do not exist
 * `false` No action will be taken when directories referenced in a link do not exist. Neovim will open a new file, but you will get an error when you attempt to write the file.
+
+#### `edit_dirs` (boolean)
+* `false` (default): When following a link that points to a directory, prompt the user to pick a file within that directory.
+* `true`: Call `:edit <directory>` when following a link that points to a directory.
+* `function(path)`: Call the supplied callback function when following a link that points to a directory.
 
 #### `perspective` (dictionary-like table)
 * `perspective.priority` (string): Specifies the priority perspective to take when interpreting link paths

--- a/lua/mkdnflow.lua
+++ b/lua/mkdnflow.lua
@@ -17,6 +17,7 @@
 -- Default config table (where defaults and user-provided config will be combined)
 local default_config = {
     create_dirs = true,
+    edit_dirs = false,
     silent = false,
     wrap = false,
     modules = {

--- a/lua/mkdnflow/paths.lua
+++ b/lua/mkdnflow/paths.lua
@@ -24,6 +24,7 @@ local this_os_err = '⬇️ Function unavailable for ' .. this_os .. '. Please f
 local sep = this_os:match('Windows') and '\\' or '/'
 -- Get config setting for whether to make missing directories or not
 local create_dirs = require('mkdnflow').config.create_dirs
+local edit_dirs = require('mkdnflow').config.edit_dirs
 -- Get config setting for where links should be relative to
 local perspective = require('mkdnflow').config.perspective
 -- Get directory of first-opened file
@@ -184,7 +185,13 @@ local internal_open = function(path, anchor)
     else
         path_w_ext = path
     end
-    if exists(path, 'd') and not exists(path_w_ext, 'f') then
+    if exists(path, 'd') and edit_dirs then
+        if edit_dirs == true then
+            vim.cmd(':e ' .. path)
+        else
+            edit_dirs(path)
+        end
+    elseif exists(path, 'd') and not exists(path_w_ext, 'f') then
         -- Looks like this links to a directory, possibly a notebook
         enter_internal_path(path)
     else


### PR DESCRIPTION
Hello,

This PR adds an `edit_dirs` option that allows users to customize how `MkdnEnter` will behave when following a link that points to a directory (e.g. `[foo](../bar/)`).

Before this PR, `:MkdnEnter` would prompt the user to pick a file name within the given directory:
![image](https://github.com/jakewvincent/mkdnflow.nvim/assets/8935917/08642ad3-aa7f-442d-9845-85bcfa4622db)

This default behavior is preserved with the new config option `edit_dirs = false`.

If `edit_dirs` is `true`, then running `:MkdnEnter` on the link `[foo](../bar/)` is equivalent to running `:edit ../bar/`. This enables the user's default directory-browsing plugin (e.g. netrw) to open the directory.

If `edit_dirs` is a callback function, then running `:MkdnEnter` on `[foo](../bar/)` is equivalent to calling `callback(path)` where `path` is the absolute version of `../bar/`