### PR TITLE
Fix/issue 193

### DIFF
--- a/lua/mkdnflow/bib.lua
+++ b/lua/mkdnflow/bib.lua
@@ -50,12 +50,13 @@ if find_in_root and root_dir then
         end
     end
     pfile:close()
-    -- Add the default bib path too
-    if type(bib_path) == 'table' then
-        M.bib_paths.default = bib_path
-    else
-        table.insert(M.bib_paths.default, bib_path)
-    end
+end
+
+-- Add the default bib path too
+if type(bib_path) == 'table' then
+    M.bib_paths.default = bib_path
+else
+    table.insert(M.bib_paths.default, bib_path)
 end
 
 local ingest_entry = function(text)

--- a/lua/mkdnflow/paths.lua
+++ b/lua/mkdnflow/paths.lua
@@ -421,7 +421,7 @@ M.handlePath = function(path, anchor)
     if path_type == 'nb_page' then
         vim_open(path, anchor)
     elseif path_type == 'url' then
-        system_open(path .. anchor, 'url')
+        system_open(path .. (anchor or ""), 'url')
     elseif path_type == 'file' then
         handle_external_file(path)
     elseif path_type == 'anchor' then


### PR DESCRIPTION
**Issue**: Fixes issue #193 

**Description**:
This pull request addresses the issue where a bib file specified in `bib.default_path` is not found. The issue was caused by an incorrect file path in the codebase. This issue was caused by the fact that `M.bib_paths.default` was being populated in the scope of an if statement that is skipped unless `find_in_root` and `root_dir` are defined.

**Changes Made**:
- Moved population of `M.bib_paths.default` with `bib_path` outside of if statement in `lua/mkdnflow/bib.lua`
- Skip concatenating `anchor` to `path` is `handlePath()` in `lua/mkdnflow/paths.lua` if anchor is `false`

**Testing**:
Tested the changes locally on Fedora environment, NVIM v0.9.5, LuaJIT 2.1.1692716794