### PR TITLE
Change `foldtext` option only for current buffer instead of globally

### DIFF
--- a/lua/mkdnflow/foldtext.lua
+++ b/lua/mkdnflow/foldtext.lua
@@ -377,6 +377,6 @@ M.fold_text = function()
     return left .. string.rep(mi, fill_count) .. right
 end
 
-vim.opt.foldtext = "v:lua.require('mkdnflow').foldtext.fold_text()"
+vim.opt_local.foldtext = "v:lua.require('mkdnflow').foldtext.fold_text()"
 
 return M


### PR DESCRIPTION
Right now, when loading the foldtext module the `foldtext` option is changed globally. This overrides the value chosen by the user in all files and leads to inconsistent behaviors, like:

- you open file A, the `foldtext` option is what you set on your personal configuration
- you open file B, a Markdown file; `foldtext` gets changed and uses the Mkdnflow version
- you go back to file A, the `foldtext` now is what Mkdnflow set

This is fixed by simply setting `foldtext` using `opt_local` instead of `opt`.