### PR TITLE
feat: only trigger suggestions for bib if @ is typed

### DIFF
--- a/lua/mkdnflow/cmp.lua
+++ b/lua/mkdnflow/cmp.lua
@@ -110,6 +110,11 @@ source.new = function()
 end
 
 function source:complete(params, callback)
+    -- Only provide suggestions if the current word in the context starts with the trigger character '@'
+    if not params.context.cursor_before_line or not params.context.cursor_before_line:match('%W@%w*$') then
+        callback({})
+        return
+    end
     local items = get_files_items()
     if bib_paths then
         -- For bib files, there are three lists (tables) in mkdnflow where we might find the paths for a bib file


### PR DESCRIPTION
This pull request includes a small change to the `lua/mkdnflow/cmp.lua` file. The change ensures that suggestions are only provided if the current word in the context starts with the trigger character '@'.

* [`lua/mkdnflow/cmp.lua`](diffhunk://#diff-7324ca0f961bf453c910cb32c75b03f0954be653474d0f1c2b9317faa06f92a4R113-R117): Added a check to only provide suggestions if the current word starts with the trigger character '@'.