### PR TITLE
bugfix: MkdnYankAnchorLink register selection

### DIFF
--- a/lua/mkdnflow/cursor.lua
+++ b/lua/mkdnflow/cursor.lua
@@ -637,7 +637,13 @@ end
 ---@param full_path? boolean If true, prepend the full buffer path to the anchor (default false)
 M.yankAsAnchorLink = function(full_path)
     full_path = full_path or false
-    local register = require('mkdnflow').config.cursor.yank_register or '"'
+    local register
+    -- prioritize yank_register over clipboard register
+    if not string.find(vim.v.register, '[*"+]') then
+        register = vim.v.register
+    else
+        register = require('mkdnflow').config.cursor.yank_register or vim.v.register
+    end
     -- Get the row number and the line contents
     local row = vim.api.nvim_win_get_cursor(0)[1]
     local line = vim.api.nvim_buf_get_lines(0, row - 1, row, false)


### PR DESCRIPTION
Solves #340

- On `"cyaa`,  it will yank to register c
if cursor.yank_register is set to nil, it will copy the content to the clipboard register,
otherwise it will copy to register specified in yank_register

Drawback :
- If cursor.yank_register is set to `"` and `"+yaa` is run in normal  mode, it will store it to yank_register regardless. I dont think there is a work around it with lua.